### PR TITLE
Safe description in article and page

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}{{ article.title }} - {{ super() }}{% endblock title %}
-{% block description %}{{ article.content|striptags|truncate(200) }}{% endblock description %}
+{% block description %}{{ article.content|striptags|truncate(200)|escape }}{% endblock description %}
 {% block keywords %}{% for tag in article.tags|sort %}{{ tag }}{% if not loop.last %}, {% endif %}{% endfor %}{% endblock keywords %}
 
 {% block headerstyle %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}{{ page.title }} - {{ super() }}{% endblock title %}
-{% block description %}{{ page.content|striptags|truncate(200) }}{% endblock description %}
+{% block description %}{{ page.content|striptags|truncate(200)|escape }}{% endblock description %}
 
 {% block headerstyle %}
     {% if NEST_HEADER_IMAGES %}


### PR DESCRIPTION
Html code and " in an article or a page can break the site.

Before:

``` html
<!DOCTYPE html>
<html lang="fr">
    <head>
        <meta charset="utf-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <meta name="description" content="Bienvenue sur mon nouveau blog. def hello_world(self): """ <html> <body> <h1>Hello, World!</h1> <body> </html> """ return __doc__">
        <meta name="keywords" content="">
        <link rel="icon" href="/favicon.ico">
```

After:

``` html
<!DOCTYPE html>
<html lang="fr">
    <head>
        <meta charset="utf-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <meta name="description" content="Bienvenue sur mon nouveau blog. def hello_world(self): &#34;&#34;&#34; &lt;html&gt; &lt;body&gt; &lt;h1&gt;Hello, World!&lt;/h1&gt; &lt;body&gt; &lt;/html&gt; &#34;&#34;&#34; return __doc__">
        <meta name="keywords" content="">
        <link rel="icon" href="/favicon.ico">
```
