### PR TITLE
Added basic linenos support in nest.css

### DIFF
--- a/static/css/nest.css
+++ b/static/css/nest.css
@@ -84,6 +84,21 @@ pre, code {
 
 code { padding: 3px 6px; }
 
+.linenos pre{
+	border:none;
+	margin-top:20px;
+	margin-bottom:20px;
+	padding-top:20px;
+	padding-bottom:20px;
+	padding-left:20px;
+	padding-right:0px;
+	background:#333;
+	font-size:14px;
+	font-weight:400;
+	font-family:Consolas,monaco,monospace;
+	color:#fff
+}
+
 .highlight pre {
   border:none;
   margin-top: 20px;


### PR DESCRIPTION
Quick fix for support line number in source code

Before:
![before](https://cloud.githubusercontent.com/assets/6305913/6575446/0b050d56-c72f-11e4-9da1-7f91976b9661.png)

After:
![after](https://cloud.githubusercontent.com/assets/6305913/6575448/0c9f6008-c72f-11e4-94ba-2392e14e2641.png)
