### PR TITLE
Added option for using NEST_LICENSE_LINK variable 

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -155,6 +155,7 @@
                             <small><em>Proudly powered by <a href="http://docs.getpelican.com/" target="_blank">pelican</a></em></small><br/>
                             <small><em>Theme and code by <a href="https://github.com/molivier" target="_blank">molivier</a></em></small><br/>
                             <small>{{ NEST_COPYRIGHT }}</small>
+                            <small><em>{{ NEST_LICENSE_LINK }}</em></small>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Hi! Thank you for your theme, it looks really good. I have made some adjustments to adequate it to my necessities. They are minor changes, almost stupid, but you might be interested in merging them...

This change allows the user to populate the variable NEST_LICENSE_LINK in pelicanconf.py with the html link some license authorities like Creative Commons provide for you, including image and explanation of the license. Creating several variables (IMAGE, TEXT, LINK) could be possible to avoid including HTML code in the pelicanconf.py. This approach was just the fastest. Let me know.

Regards
