### PR TITLE
Support rel canonical link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ THEME = 'nest'
 SITESUBTITLE = u'My Awesome Blog'
 # Minified CSS
 NEST_CSS_MINIFY = True
+# Add canonical link element to top page header and all article/author/category/tag page header
+NEST_REL_CANONICAL_LINK = True
 # Add items to top menu before pages
 MENUITEMS = [('Homepage', '/'),('Categories','/categories.html')]
 # Add header background image from content/images : 'background.jpg'

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,21 @@
         <meta name="description" content="{% block description %}{% endblock description %}">
         <meta name="keywords" content="{% block keywords %}{% endblock keywords %}">
         <link rel="icon" href="{{ SITEURL }}/favicon.ico">
+        {% if NEST_REL_CANONICAL_LINK %}
+        <!-- Canonical -->
+        {% if article %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}">
+        {% elif author %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ author.url }}">
+        {% elif category %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ category.url }}">
+        {% elif tag %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ tag.url }}">
+        {% else %}
+        <link rel="canonical" href="{{ SITEURL }}">
+        {% endif %}
+        <!-- /Canonical -->
+        {% endif %}
 
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
 


### PR DESCRIPTION
Hi, I would like to set up to tell Google and other search engines the canonical URLs.

If the user sets `NEST_REL_CANONICAL_LINK` to `True`, the article page will have a `rel = canonical <link>` tag written out.

```html
<link rel="icon" href="https://example.com/favicon.ico">
<!-- Canonical -->
<link rel="canonical" href="https://example.com/article.html">
<!-- /Canonical -->
```

See also)
https://support.google.com/webmasters/answer/139066

Thank you for maintaining the great design theme.